### PR TITLE
support migration auto without manually adding migrationService call …

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository contains source code of Mongogee, and a testing sample host Grai
 In host Grails application's build.gradle file:
 
 	plugins {
-    	compile ':mongogee:$version' // current: 0.6
+    	compile ':mongogee:$version'
 	}
 
 
@@ -81,7 +81,9 @@ Change-logs can be written in either Java or Groovy. Some groovy examples are be
     
 ## RUN MIGRATION
 
-Add following to init/BootStrap.groovy
+**Version 0.9 and up:** The manual line adding below is no longer needed. Mongogee migration service will be executed automatically if `changeEnabled` is set to `true` (which is also default).
+
+**Version 0.8 and below:** Add following to init/BootStrap.groovy
 
 ```groovy
 class BootStrap {

--- a/mongogee/build.gradle
+++ b/mongogee/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 }
 
-version "0.8"
+version "0.9"
 group "org.grails.plugins"
 
 apply plugin:"eclipse"

--- a/mongogee/src/main/groovy/grails/plugin/mongogee/MongogeeGrailsPlugin.groovy
+++ b/mongogee/src/main/groovy/grails/plugin/mongogee/MongogeeGrailsPlugin.groovy
@@ -116,6 +116,8 @@ class MongogeeGrailsPlugin extends Plugin {
         }
         log.info "set mongogeeService.lockingRetryMax = ${mongogeeServiceBean.lockingRetryMax}"
 
+        // ** execute migration service if enabled **
+        mongogeeServiceBean.execute()
     }
 
     void onChange(Map<String, Object> event) {

--- a/test-g3-mongodb/build.gradle
+++ b/test-g3-mongodb/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 }
 
-version "0.1"
+version "0.2"
 group "test.g3.mongodb"
 
 apply plugin:"eclipse"

--- a/test-g3-mongodb/grails-app/init/test/g3/mongodb/BootStrap.groovy
+++ b/test-g3-mongodb/grails-app/init/test/g3/mongodb/BootStrap.groovy
@@ -1,11 +1,9 @@
 package test.g3.mongodb
 
 import grails.core.GrailsApplication
-import grails.plugin.mongogee.MongogeeService
 
 class BootStrap {
     GrailsApplication grailsApplication
-    MongogeeService mongogeeService
 
     def init = { servletContext ->
 
@@ -17,9 +15,6 @@ class BootStrap {
         log.info "mongogee.lockingRetryEnabled: ${grailsApplication.config.mongogee.lockingRetryEnabled}"
         log.info "mongogee.lockingRetryIntervalMillis: ${grailsApplication.config.mongogee.lockingRetryIntervalMillis}"
         log.info "mongogee.lockingRetryMax: ${grailsApplication.config.mongogee.lockingRetryMax}"
-
-        mongogeeService.execute()
-
     }
 
     def destroy = {


### PR DESCRIPTION
…in host app bootstrap;

bump version to 0.9;
bump sample host app version to 0.2.